### PR TITLE
[fix issue #23] Docker Support for Self-Hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine
+
+
+# installing git to clone the app 
+RUN apk add --no-cache git 
+
+WORKDIR /app
+
+# cloning the repo of the app
+RUN git clone https://github.com/unicodeveloper/globalthreatmap.git .
+
+# install the app with dependencies
+RUN npm install --legacy-peer-deps
+
+# Needed to reach the app from outside
+EXPOSE 3000
+
+# runing the app
+CMD ["npm", "run", "dev"]
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    # this is the file where you are suppose to put on your API keys
+    env_file:
+      - dot_env
+    ports:
+      - "3000:3000"

--- a/dot_env
+++ b/dot_env
@@ -1,0 +1,6 @@
+NEXT_PUBLIC_MAPBOX_TOKEN=your_mapbox_token_here
+VALYU_API_KEY=your_valyu_api_key_here
+NEXT_PUBLIC_APP_MODE=self-hosted
+
+# Optional: Enable AI-powered location extraction for better accuracy
+OPENAI_API_KEY=your_openai_api_key_here


### PR DESCRIPTION
This is related to the issue #23 where users are asking for a docker image in order to self host the app. I tried to keep it as lean as possible. Let me know if there's any issues with my work.

I made the docker file to make the image from node and a compose to make it easier to deployed. The architechture of the app was already based on env vars for secrets so it seems it was built for docker portability.

The compose file simply up the image

the dot_env file is the same that is specified in the documentation